### PR TITLE
Attributes.swift Img.load

### DIFF
--- a/Sources/DOM/Attributes.swift
+++ b/Sources/DOM/Attributes.swift
@@ -4004,29 +4004,27 @@ extension Video: SrcAttrable {}
 // MARK: - LoadAttrable
 
 public protocol LoadAttrable: DOMElement {
-	@discardableResult
-	func load<U: URLConformable>(_ value: U) -> Self
+    @discardableResult
+    func load<U: URLConformable>(_ value: U) -> Self
 }
 
 extension LoadAttrable {
-	/// The URL of the embeddable content.
-	///
-	/// Applicable to `<img>`
-	///
-	/// [More info →](https://www.w3schools.com/tags/att_src.asp)
-	@discardableResult
-	public func load<U: URLConformable>(_ value: U) -> Self {
-		let tempImg = Img()
-		tempImg
-			.src(value.stringValue)
-			.onLoad {
-				self.setAttribute("src", value.stringValue)
-				tempImg.remove()
-			}
-			
-		return self
-	}
-	
+    /// The URL of the embeddable content.
+    ///
+    /// Applicable to `<img>`
+    ///
+    /// [More info →](https://www.w3schools.com/tags/att_src.asp)
+    @discardableResult
+    public func load<U: URLConformable>(_ value: U) -> Self {
+        let tempImg = Img()
+        tempImg
+        .src(value.stringValue)
+        .onLoad {
+            self.setAttribute("src", value.stringValue)
+            tempImg.remove()
+        }
+        return self
+    }
 }
 
 extension Img: LoadAttrable {}

--- a/Sources/DOM/Attributes.swift
+++ b/Sources/DOM/Attributes.swift
@@ -4001,6 +4001,36 @@ extension Source: SrcAttrable {}
 extension Track: SrcAttrable {}
 extension Video: SrcAttrable {}
 
+// MARK: - LoadAttrable
+
+public protocol LoadAttrable: DOMElement {
+	@discardableResult
+	func load<U: URLConformable>(_ value: U) -> Self
+}
+
+extension LoadAttrable {
+	/// The URL of the embeddable content.
+	///
+	/// Applicable to `<img>`
+	///
+	/// [More info →](https://www.w3schools.com/tags/att_src.asp)
+	@discardableResult
+	public func load<U: URLConformable>(_ value: U) -> Self {
+		let tempImg = Img()
+		tempImg
+			.src(value.stringValue)
+			.onLoad {
+				self.setAttribute("src", value.stringValue)
+				tempImg.remove()
+			}
+			
+		return self
+	}
+	
+}
+
+extension Img: LoadAttrable {}
+
 // MARK: - SrcDocAttrable
 
 public protocol SrcDocAttrable: DOMElement {


### PR DESCRIPTION
The folowing fix blows to load an image async while showing a default image. Once the image has loaded  in the background it will  replace existing img.src