### PR TITLE
openURL in Window

### DIFF
--- a/Sources/DOM/Window.swift
+++ b/Sources/DOM/Window.swift
@@ -302,4 +302,26 @@ public class Window: EventListenerCompatibleObject, EventTarget {
         enterForegroundHandlers.append(handler)
         return self
     }
+
+    // MARK: Open URL
+
+    /// The openURL() method opens a new browser window, or a new tab, depending on your browser settings and the parameter values.
+    @discardableResult
+    public func openURL(
+        _ url: URLConformable = "about:blank",
+        target: TargetType = .blank,
+        options: String = ""
+    ) -> JSValue {
+        JSObject.global.window.open(url, target.rawValue, options)
+    }
+
+    /// The openURL() method opens a new browser window, or a new tab, depending on your browser settings and the parameter values.
+    @discardableResult
+    public func openURL(
+        _ url: URLConformable = "about:blank",
+        name: String = "",
+        options: String = ""
+    ) -> JSValue {
+        JSObject.global.window.open(url, name, options)
+    }
 }


### PR DESCRIPTION
## Description
Added method to open URL in Window class.

## Usage
```swift
Window.shared.openURL("https://github.com")

Window.shared.openURL("https://github.com", target: .parent)

Window.shared.openURL("https://github.com", name: "pop01", options: "height=100, width=100")
```
